### PR TITLE
fix: ビルド時の markdown に関する警告を解決する

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,6 +1,7 @@
 // @ts-check
 import { defineConfig } from 'astro/config';
 
+import { unified } from '@astrojs/markdown-remark';
 import react from '@astrojs/react';
 import sitemap from '@astrojs/sitemap';
 import icon from 'astro-icon';
@@ -51,7 +52,9 @@ export default defineConfig({
       wrap: true,
     },
     syntaxHighlight: 'shiki',
-    remarkPlugins: [remarkMath],
-    rehypePlugins: [rehypeKatex, rehypeSlug],
+    processor: unified({
+      remarkPlugins: [remarkMath],
+      rehypePlugins: [rehypeKatex, rehypeSlug],
+    }),
   },
 });

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   },
   "dependencies": {
     "@astrojs/check": "^0.9.8",
+    "@astrojs/markdown-remark": "^7.2.0",
     "@astrojs/mdx": "^6.0.0",
     "@astrojs/react": "^5.0.2",
     "@astrojs/sitemap": "^3.7.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@astrojs/check':
         specifier: ^0.9.8
         version: 0.9.9(prettier@3.8.3)(typescript@6.0.3)
+      '@astrojs/markdown-remark':
+        specifier: ^7.2.0
+        version: 7.2.0
       '@astrojs/mdx':
         specifier: ^6.0.0
         version: 6.0.1(astro@6.4.2(@types/node@25.9.1)(rollup@4.60.4)(yaml@2.9.0))


### PR DESCRIPTION
```
[astro] `markdown.remarkPlugins`, `markdown.rehypePlugins`, and `markdown.remarkRehype` are deprecated. Pass them to `unified({...})` from `@astrojs/markdown-remark` directly instead.
```

という警告が出ているので修正する。
